### PR TITLE
Set vault to create MI 

### DIFF
--- a/vault.tf
+++ b/vault.tf
@@ -6,6 +6,7 @@ module "vault" {
   object_id                            = var.jenkins_AAD_objectId
   resource_group_name                  = azurerm_resource_group.infrastructure_resource_group.name
   product_group_object_id              = "e7ea2042-4ced-45dd-8ae3-e051c6551789" # DTS Platform Operations
+  create_managed_identity              = true
   common_tags                          = local.tags
 }
 


### PR DESCRIPTION
### Jira link (if applicable)



### Change description ###
- Setting `create_managed_identity` to true so MI can be used to retrieve key vault secrets in K8s pods

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
